### PR TITLE
Fix gson serde compatibility issues with newer jvms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ allprojects {
         testCompile "org.testcontainers:kafka:1.15.0-rc2"
         testCompile "org.testcontainers:mockserver:1.15.0-rc2"
         testCompile "org.mock-server:mockserver-client-java:5.11.1"
-        testCompile "com.google.code.gson:gson:2.8.6"
+        testCompile "com.google.code.gson:gson:2.11.0"
 
         testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '2.26.0'
         compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.15.0'

--- a/source/build.gradle
+++ b/source/build.gradle
@@ -1,7 +1,7 @@
 description = "Kafka Connect Source connector that reads from DynamoDB streams"
 
 dependencies {
-    implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.google.code.gson:gson:2.11.0'
     implementation 'com.amazonaws:aws-java-sdk-resourcegroupstaggingapi:1.11.551'
 
     compile group: 'org.apache.kafka', name: 'connect-api', version: "${rootProject.ext.kafkaConnectApiVersion}"

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/SourceInfo.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/SourceInfo.java
@@ -2,13 +2,16 @@ package com.trustpilot.connector.dynamodb;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import com.trustpilot.connector.dynamodb.utils.ByteBufferTypeAdapter;
 import com.trustpilot.connector.dynamodb.utils.SchemaNameAdjuster;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 
 import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -23,7 +26,10 @@ import java.util.Map;
  * It's also stored together with each event value sent to Kafka topic for traceability.
  */
 public class SourceInfo {
-    private static final Gson gson = new Gson();
+    private static final Gson gson = new GsonBuilder()
+            // use `ByteBufferTypeAdapter` to support `AttributeValue` serde (i.e. `exclusiveStartKey`)
+            .registerTypeAdapter(ByteBuffer.class, new ByteBufferTypeAdapter())
+            .create();
     private final Clock clock;
 
     public final String version;

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/utils/ByteBufferTypeAdapter.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/utils/ByteBufferTypeAdapter.java
@@ -2,8 +2,6 @@ package com.trustpilot.connector.dynamodb.utils;
 
 import com.amazonaws.util.Base64;
 import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
@@ -19,8 +17,7 @@ public class ByteBufferTypeAdapter extends TypeAdapter<ByteBuffer> {
 
     @Override
     public void write(JsonWriter jsonWriter, ByteBuffer buffer) throws IOException {
-        if (buffer == null)
-        {
+        if (buffer == null) {
             jsonWriter.nullValue();
         }
         else {
@@ -33,13 +30,11 @@ public class ByteBufferTypeAdapter extends TypeAdapter<ByteBuffer> {
 
     @Override
     public ByteBuffer read(JsonReader jsonReader) throws IOException {
-        if (jsonReader.peek() == JsonToken.NULL)
-        {
+        if (jsonReader.peek() == JsonToken.NULL) {
             jsonReader.nextNull();
             return null;
         }
-        else if (jsonReader.peek() == JsonToken.BEGIN_OBJECT)
-        {
+        else if (jsonReader.peek() == JsonToken.BEGIN_OBJECT) {
             // A reasonable, limited effort for this use case to rehydrate a json formatted object representing
             // the internal properties of a ByteBuffer. This is for backwards compatibility with byte buffers
             // serialized using default gson serializers (i.e. ones that pluck out internal fields of types), which
@@ -47,8 +42,7 @@ public class ByteBufferTypeAdapter extends TypeAdapter<ByteBuffer> {
             // and 2) accessing these internal properties breaks on newer jvms enforcing stricktly
             // java modules security boundaries and it's best to avoid hacks to open modules up.
             Map properties = GSON.fromJson(jsonReader, Map.class);
-            if (!properties.containsKey("hb"))
-            {
+            if (!properties.containsKey("hb")) {
                 throw new RuntimeException("Unexpected ByteBuffer encoding. Does not contain a 'hb' field.");
             }
 

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/utils/ByteBufferTypeAdapter.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/utils/ByteBufferTypeAdapter.java
@@ -1,0 +1,72 @@
+package com.trustpilot.connector.dynamodb.utils;
+
+import com.amazonaws.util.Base64;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+public class ByteBufferTypeAdapter extends TypeAdapter<ByteBuffer> {
+    private static final Gson GSON = new Gson();
+
+    @Override
+    public void write(JsonWriter jsonWriter, ByteBuffer buffer) throws IOException {
+        if (buffer == null)
+        {
+            jsonWriter.nullValue();
+        }
+        else {
+            byte[] bytes = new byte[buffer.remaining()];
+            buffer.get(bytes);
+            buffer.rewind();
+            jsonWriter.value(Base64.encodeAsString(bytes));
+        }
+    }
+
+    @Override
+    public ByteBuffer read(JsonReader jsonReader) throws IOException {
+        if (jsonReader.peek() == JsonToken.NULL)
+        {
+            jsonReader.nextNull();
+            return null;
+        }
+        else if (jsonReader.peek() == JsonToken.BEGIN_OBJECT)
+        {
+            // A reasonable, limited effort for this use case to rehydrate a json formatted object representing
+            // the internal properties of a ByteBuffer. This is for backwards compatibility with byte buffers
+            // serialized using default gson serializers (i.e. ones that pluck out internal fields of types), which
+            // are best avoided now because 1) it's an implementation detail of the jvm and subject to change
+            // and 2) accessing these internal properties breaks on newer jvms enforcing stricktly
+            // java modules security boundaries and it's best to avoid hacks to open modules up.
+            Map properties = GSON.fromJson(jsonReader, Map.class);
+            if (!properties.containsKey("hb"))
+            {
+                throw new RuntimeException("Unexpected ByteBuffer encoding. Does not contain a 'hb' field.");
+            }
+
+            List hb = (List)properties.get("hb");
+            ByteBuffer buf = ByteBuffer.allocate(hb.size());
+
+            for (Object elem : hb) {
+                buf.put(((Double)elem).byteValue());
+            }
+            buf.position(((Double)properties.get("position")).intValue());
+
+            return buf;
+        }
+        else if (jsonReader.peek() == JsonToken.STRING) {
+            String base64 = jsonReader.nextString();
+            byte[] bytes = Base64.decode(base64);
+            return ByteBuffer.wrap(bytes);
+        }
+        throw new RuntimeException("Unexpected JSON token: " + jsonReader.peek().name());
+    }
+}

--- a/source/src/test/java/com/trustpilot/connector/dynamodb/StubOffsetStorageReader.java
+++ b/source/src/test/java/com/trustpilot/connector/dynamodb/StubOffsetStorageReader.java
@@ -1,7 +1,7 @@
 package com.trustpilot.connector.dynamodb;
 
 import org.apache.kafka.connect.storage.OffsetStorageReader;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+import java.lang.UnsupportedOperationException;
 
 import java.util.Collection;
 import java.util.Map;
@@ -25,6 +25,6 @@ public class StubOffsetStorageReader implements OffsetStorageReader {
 
     @Override
     public <T> Map<Map<String, T>, Map<String, Object>> offsets(Collection<Map<String, T>> partitions) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 }

--- a/source/src/test/java/com/trustpilot/connector/dynamodb/utils/ByteBufferTypeAdapterTests.java
+++ b/source/src/test/java/com/trustpilot/connector/dynamodb/utils/ByteBufferTypeAdapterTests.java
@@ -1,0 +1,89 @@
+package com.trustpilot.connector.dynamodb.utils;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.util.Base64;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ByteBufferTypeAdapterTests {
+    private final Gson gson = new GsonBuilder()
+            .registerTypeAdapter(ByteBuffer.class, new ByteBufferTypeAdapter())
+            .create();
+
+    @Test
+    public void shouldSerializeByteBufferAttributeValue()
+    {
+        byte[] bytes = "sajdlfjaslkjflsajflkasjflkaj".getBytes(StandardCharsets.UTF_8);
+        ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+
+        AttributeValue av = new AttributeValue();
+        av.setB(byteBuffer);
+
+        JsonElement jsonTree = gson.toJsonTree(av);
+        byte[] fromJson = Base64.decode(jsonTree.getAsJsonObject().get("b").getAsString());
+        assertArrayEquals(bytes, fromJson);
+    }
+
+    @Test
+    public void shouldDeserializeByteBufferAttributeValue()
+    {
+        String json = "{\"b\": \"c2FqZGxmamFzbGtqZmxzYWpmbGthc2pmbGthag==\"}";
+        AttributeValue av = gson.fromJson(json, AttributeValue.class);
+
+        assertEquals("sajdlfjaslkjflsajflkasjflkaj", StandardCharsets.UTF_8.decode(av.getB()).toString());
+    }
+
+    @Test
+    public void shouldDeserializeByteBufferAttributeValueFromRaw()
+    {
+        // Handle the case where we are loading a "legacy" json encoded ByteBuffer
+        // that contains internal fields (
+        String legacyByteBufferJson = "{\"b\":{\"hb\":[115,97,106,100,108,102,106,97,115,108,107,106,102,108,115,97,106,102,108,107,97,115,106,102,108,107,97,106],\"offset\":0,\"isReadOnly\":false,\"bigEndian\":true,\"nativeByteOrder\":false,\"mark\":-1,\"position\":0,\"limit\":28,\"capacity\":28,\"address\":0}}";
+        AttributeValue av = gson.fromJson(legacyByteBufferJson, AttributeValue.class);
+
+        assertEquals("sajdlfjaslkjflsajflkasjflkaj", StandardCharsets.UTF_8.decode(av.getB()).toString());
+    }
+
+    @Test
+    public void shouldSerializeNullByteBufferAttributeValue()
+    {
+        AttributeValue av = new AttributeValue();
+
+        JsonElement jsonTree = gson.toJsonTree(av);
+        assertFalse(jsonTree.getAsJsonObject().has("b"));
+    }
+
+    @Test
+    public void shouldDeserializeNullByteBufferAttributeValue()
+    {
+        String json = "{\"b\": null}";
+        AttributeValue av = gson.fromJson(json, AttributeValue.class);
+        assertNull(av.getB());
+    }
+
+    @Test
+    public void shouldSerializeEmptyByteBufferAttributeValue()
+    {
+        AttributeValue av = new AttributeValue();
+        av.setB(ByteBuffer.allocate(0));
+
+        JsonElement jsonTree = gson.toJsonTree(av);
+        byte[] fromJson = Base64.decode(jsonTree.getAsJsonObject().get("b").getAsString());
+        assertEquals(0, fromJson.length);
+    }
+
+    @Test
+    public void shouldDeserializeEmptyByteBufferAttributeValue()
+    {
+        String json = "{\"b\": \"\"}";
+        AttributeValue av = gson.fromJson(json, AttributeValue.class);
+        assertEquals(0, av.getB().capacity());
+    }
+}

--- a/source/src/test/java/com/trustpilot/connector/dynamodb/utils/ByteBufferTypeAdapterTests.java
+++ b/source/src/test/java/com/trustpilot/connector/dynamodb/utils/ByteBufferTypeAdapterTests.java
@@ -18,8 +18,7 @@ public class ByteBufferTypeAdapterTests {
             .create();
 
     @Test
-    public void shouldSerializeByteBufferAttributeValue()
-    {
+    public void shouldSerializeByteBufferAttributeValue() {
         byte[] bytes = "sajdlfjaslkjflsajflkasjflkaj".getBytes(StandardCharsets.UTF_8);
         ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
 
@@ -32,8 +31,7 @@ public class ByteBufferTypeAdapterTests {
     }
 
     @Test
-    public void shouldDeserializeByteBufferAttributeValue()
-    {
+    public void shouldDeserializeByteBufferAttributeValue() {
         String json = "{\"b\": \"c2FqZGxmamFzbGtqZmxzYWpmbGthc2pmbGthag==\"}";
         AttributeValue av = gson.fromJson(json, AttributeValue.class);
 
@@ -41,8 +39,7 @@ public class ByteBufferTypeAdapterTests {
     }
 
     @Test
-    public void shouldDeserializeByteBufferAttributeValueFromRaw()
-    {
+    public void shouldDeserializeByteBufferAttributeValueFromRaw() {
         // Handle the case where we are loading a "legacy" json encoded ByteBuffer
         // that contains internal fields (
         String legacyByteBufferJson = "{\"b\":{\"hb\":[115,97,106,100,108,102,106,97,115,108,107,106,102,108,115,97,106,102,108,107,97,115,106,102,108,107,97,106],\"offset\":0,\"isReadOnly\":false,\"bigEndian\":true,\"nativeByteOrder\":false,\"mark\":-1,\"position\":0,\"limit\":28,\"capacity\":28,\"address\":0}}";
@@ -52,8 +49,7 @@ public class ByteBufferTypeAdapterTests {
     }
 
     @Test
-    public void shouldSerializeNullByteBufferAttributeValue()
-    {
+    public void shouldSerializeNullByteBufferAttributeValue() {
         AttributeValue av = new AttributeValue();
 
         JsonElement jsonTree = gson.toJsonTree(av);
@@ -61,16 +57,14 @@ public class ByteBufferTypeAdapterTests {
     }
 
     @Test
-    public void shouldDeserializeNullByteBufferAttributeValue()
-    {
+    public void shouldDeserializeNullByteBufferAttributeValue() {
         String json = "{\"b\": null}";
         AttributeValue av = gson.fromJson(json, AttributeValue.class);
         assertNull(av.getB());
     }
 
     @Test
-    public void shouldSerializeEmptyByteBufferAttributeValue()
-    {
+    public void shouldSerializeEmptyByteBufferAttributeValue() {
         AttributeValue av = new AttributeValue();
         av.setB(ByteBuffer.allocate(0));
 
@@ -80,8 +74,7 @@ public class ByteBufferTypeAdapterTests {
     }
 
     @Test
-    public void shouldDeserializeEmptyByteBufferAttributeValue()
-    {
+    public void shouldDeserializeEmptyByteBufferAttributeValue() {
         String json = "{\"b\": \"\"}";
         AttributeValue av = gson.fromJson(json, AttributeValue.class);
         assertEquals(0, av.getB().capacity());


### PR DESCRIPTION
Use custom type adapter for ByteBuffer json serde

In order to convert `AttributeValue` in newer JVMs that restrict
access to protected modules create a gson type adapter for
`ByteBuffer`s.

The adapter should be able to import "legacy" encoded ByteBuffers
(i.e. those encoded with internal ByteBuffer fields and reflection)
and then use the cleaner formatting of encoding this as base64 strings
in the json (instead of an array of doubles, and other internal fields).